### PR TITLE
Creates new "transformed" directory for the transformed data, require…

### DIFF
--- a/harvest_transformer/__main__.py
+++ b/harvest_transformer/__main__.py
@@ -55,7 +55,7 @@ def transform_key(file_name: str, source: str, target: str) -> str:
     """Creates a key in a transformed subdirectory from a given file name"""
     transformed_key = file_name.replace("git-harvester", "transformed", 1)
     if transformed_key == file_name:
-        transformed_key = "transformed" + file_name.replace(source, target)
+        transformed_key = "transformed/" + file_name.replace(source, target)
     return transformed_key
 
 


### PR DESCRIPTION
## Updated for Workflow Outputs
Updated functionality to create a new `transformed` directory for transformed data, when `git-harvester` is not present in the file key. This ensures the transformed data is always in a `transformed` directory, whether it was previously in the `git-harvester` directory or not.
This is required when ingesting workflow outputs, as the first part of the key is always assumed to be `transformed/` just as with harvested STAC Catalog data.