### PR TITLE
EODHP-1035 Links to STAC aggregations

### DIFF
--- a/harvest_transformer/transformer.py
+++ b/harvest_transformer/transformer.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from typing import Union
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import boto3
 
@@ -142,7 +142,7 @@ def transform(
     """Load file from given key as json and update by applying list of processors"""
 
     # Compose target_location
-    target_location = output_root + target
+    target_location = urljoin(output_root, target)
 
     # Update catalog ID if necessary
     entry_body = update_catalog_id(entry_body, target)


### PR DESCRIPTION
This fixes the join of output root and target so that it is always a valid url. Prevents links such as "https://dev.eodatahub.org.uksupported-datasets/ceda-stac-catalogue/" from forming.