### PR TITLE
no longer rewrite catalog IDs if root

### DIFF
--- a/harvest_transformer/transformer.py
+++ b/harvest_transformer/transformer.py
@@ -196,8 +196,8 @@ def transform(
     target_location = urljoin(output_root, target)
 
     # Update catalog ID if necessary
-    if isinstance(entry_body, dict):
-        entry_body = update_catalog_id(entry_body, target)
+    # if isinstance(entry_body, dict):
+    #     entry_body = update_catalog_id(entry_body, target)
 
     # Define list of processors
     processors = [WorkflowProcessor(), LinkProcessor(workspace), RenderProcessor()]


### PR DESCRIPTION
## Remove Update Catalog ID
- This was causing issues, as many catalogs had their IDs updated incorrectly
- This may mean we have issues with harvested catalogs that have the same ID e.g. `stac-fastapi` so we might need to update these elsewhere in the harvest pipeline