### PR TITLE
Harvest pipeline speedups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install --yes --quiet --no-install-recommends \
     openssh-client \
     procps \
-    git
+    git \
+    g++
 
 RUN --mount=type=cache,target=/root/.cache/pip python -m pip install --upgrade pip
 

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,4 @@ setup: venv requirements .make-venv-installed .git/hooks/pre-commit
 restart-k8s:
 	kubectl rollout -n rc restart deployment/transform-catalogue-data
 	kubectl rollout -n rc restart deployment/transform-catalogue-data-stac
+	kubectl rollout -n rc restart deployment/transform-catalogue-data-bulk

--- a/harvest_transformer/__main__.py
+++ b/harvest_transformer/__main__.py
@@ -27,7 +27,7 @@ def main(verbose: int, threads: int):
 
     # Configure S3 client.
     s3_client = get_boto3_session().client(
-        "s3", config=botocore.client.Config(max_pool_connections=min(threads, 10))
+        "s3", config=botocore.client.Config(max_pool_connections=max(threads * 2, 10))
     )
 
     if os.getenv("TOPIC"):
@@ -49,7 +49,7 @@ def main(verbose: int, threads: int):
     destination_bucket = os.environ.get("S3_BUCKET")
 
     transformer_messager = TransformerMessager(
-        processors=[WorkflowProcessor(), LinkProcessor(), RenderProcessor()],
+        processors=[WorkflowProcessor(), LinkProcessor(s3_client=s3_client), RenderProcessor()],
         s3_client=s3_client,
         output_bucket=destination_bucket,
         cat_output_prefix="transformed/",

--- a/harvest_transformer/__main__.py
+++ b/harvest_transformer/__main__.py
@@ -22,7 +22,7 @@ from .transformer_messager import TransformerMessager
 @click.option("-t", "--threads", type=int, default=1)
 def main(verbose: int, threads: int):
     setup_logging(verbosity=verbose)
-    log_component_version("harvest_transformer")
+    log_component_version("harvest-transformer")
 
     # Configure S3 client
     s3_client = get_boto3_session().client("s3")

--- a/harvest_transformer/__main__.py
+++ b/harvest_transformer/__main__.py
@@ -10,6 +10,10 @@ from eodhp_utils.runner import (
     setup_logging,
 )
 
+from harvest_transformer.link_processor import LinkProcessor
+from harvest_transformer.render_processor import RenderProcessor
+from harvest_transformer.workflow_processor import WorkflowProcessor
+
 from .transformer_messager import TransformerMessager
 
 
@@ -42,6 +46,7 @@ def main(verbose: int, threads: int):
     destination_bucket = os.environ.get("S3_BUCKET")
 
     transformer_messager = TransformerMessager(
+        processors=[WorkflowProcessor(), LinkProcessor(), RenderProcessor()],
         s3_client=s3_client,
         output_bucket=destination_bucket,
         cat_output_prefix="transformed/",

--- a/harvest_transformer/__main__.py
+++ b/harvest_transformer/__main__.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 
+import botocore
 import click
 from eodhp_utils.runner import (
     get_boto3_session,
@@ -24,8 +25,10 @@ def main(verbose: int, threads: int):
     setup_logging(verbosity=verbose)
     log_component_version("harvest-transformer")
 
-    # Configure S3 client
-    s3_client = get_boto3_session().client("s3")
+    # Configure S3 client.
+    s3_client = get_boto3_session().client(
+        "s3", config=botocore.client.Config(max_pool_connections=min(threads, 10))
+    )
 
     if os.getenv("TOPIC"):
         identifier = "_" + os.getenv("TOPIC")

--- a/harvest_transformer/__main__.py
+++ b/harvest_transformer/__main__.py
@@ -35,7 +35,7 @@ def main(verbose: int, threads: int):
     producer_id = os.getenv("PRODUCER_UNIQUE_SUFFIX", str(uuid.uuid4()))
 
     # Initiate Pulsar
-    pulsar_client = get_pulsar_client()
+    pulsar_client = get_pulsar_client(message_listener_threads=threads)
 
     producer = pulsar_client.create_producer(
         topic=f"transformed{identifier}",

--- a/harvest_transformer/transformer.py
+++ b/harvest_transformer/transformer.py
@@ -9,10 +9,6 @@ import botocore
 import botocore.exceptions
 import jsonpatch
 
-from .link_processor import LinkProcessor
-from .render_processor import RenderProcessor
-from .workflow_processor import WorkflowProcessor
-
 # configure boto3 logging
 logging.getLogger("botocore").setLevel(logging.CRITICAL)
 logging.getLogger("boto3").setLevel(logging.CRITICAL)
@@ -83,6 +79,7 @@ def update_file(
     entry_body: Union[dict, str],
     output_root: str,
     processors: list,
+    workspace: str,
 ) -> str:
     """
     Updates content within a given file name. File name is an S3 key.
@@ -96,6 +93,7 @@ def update_file(
             target_location=target_location,
             entry_body=entry_body,
             output_root=output_root,
+            workspace=workspace,
         )
 
     # Convert json to string for file upload
@@ -173,6 +171,7 @@ def apply_patch(original: dict, patch: list) -> dict:
 
 
 def transform(
+    processors,
     file_name: str,
     entry_body: Union[dict, str],
     source: str,
@@ -198,11 +197,14 @@ def transform(
     # Update catalog ID if necessary
     # if isinstance(entry_body, dict):
     #     entry_body = update_catalog_id(entry_body, target)
-
-    # Define list of processors
-    processors = [WorkflowProcessor(), LinkProcessor(workspace), RenderProcessor()]
     entry_body = update_file(
-        file_name, source, target_location, entry_body, output_root, processors
+        file_name,
+        source,
+        target_location,
+        entry_body,
+        output_root,
+        processors,
+        workspace,
     )
 
     return entry_body

--- a/harvest_transformer/transformer_messager.py
+++ b/harvest_transformer/transformer_messager.py
@@ -12,12 +12,17 @@ from .transformer import transform, transform_key
 
 
 class TransformerMessager(CatalogueChangeBodyMessager):
+    def __init__(self, processors, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.processors = processors
+
     def process_update_body(
         self, entry_body: Union[dict, str], cat_path: str, source: str, target: str
     ) -> Sequence[CatalogueChangeMessager.Action]:
         workspace_from_msg = self.get_workspace_from_msg()
         output_root = os.getenv("OUTPUT_ROOT")
         entry_body = transform(
+            processors=self.processors,
             file_name=cat_path,
             entry_body=entry_body,
             source=source,

--- a/harvest_transformer/transformer_messager.py
+++ b/harvest_transformer/transformer_messager.py
@@ -29,6 +29,7 @@ class TransformerMessager(CatalogueChangeBodyMessager):
             target=target,
             output_root=output_root,
             workspace=workspace_from_msg,
+            s3_client=self.s3_client,
         )
         updated_key = transform_key(cat_path, source, target)
         return [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "html-sanitizer",
     "jsonpatch",
     "click",
-    "eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@multithreading-not-using-multi-threads"
+    "eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.12"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "html-sanitizer",
     "jsonpatch",
     "click",
-    "eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.8"
+    "eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@multithreading-not-using-multi-threads"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "Harvest-Transformer"
+name = "harvest-transformer"
 dynamic = ["version"]
 description = "Transform files recently updated by harvesters to be suitable for use in the EODH catalogue"
 readme = "README.md"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,17 +11,17 @@ attrs==25.3.0
 beautifulsoup4==4.13.4
     # via html-sanitizer
 black==25.1.0
-    # via Harvest-Transformer (pyproject.toml)
-boto3==1.38.31
+    # via harvest-transformer (pyproject.toml)
+boto3==1.38.33
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
+    #   harvest-transformer (pyproject.toml)
     #   moto
-botocore==1.38.31
+botocore==1.38.33
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   boto3
     #   eodhp-utils
+    #   harvest-transformer (pyproject.toml)
     #   moto
     #   s3transfer
 build==1.2.2.post1
@@ -38,15 +38,15 @@ charset-normalizer==3.4.2
     # via requests
 click==8.2.1
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   black
+    #   harvest-transformer (pyproject.toml)
     #   pip-tools
-cryptography==45.0.3
+cryptography==45.0.4
     # via moto
 distlib==0.3.9
     # via virtualenv
-eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@multithreading-not-using-multi-threads
-    # via Harvest-Transformer (pyproject.toml)
+eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.12
+    # via harvest-transformer (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist
 faker==37.3.0
@@ -56,7 +56,7 @@ fastjsonschema==2.21.1
 filelock==3.18.0
     # via virtualenv
 html-sanitizer==2.5.0
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 identify==2.6.12
     # via pre-commit
 idna==3.10
@@ -66,7 +66,7 @@ importlib-metadata==8.7.0
 iniconfig==2.1.0
     # via pytest
 isort==6.0.1
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 jinja2==3.1.6
     # via moto
 jmespath==1.0.1
@@ -74,13 +74,13 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 jsonpatch==1.33
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
 jsonschema==4.24.0
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
+    #   harvest-transformer (pyproject.toml)
 jsonschema-specifications==2025.4.1
     # via jsonschema
 lxml==5.4.0
@@ -94,12 +94,12 @@ markupsafe==3.0.2
     #   jinja2
     #   werkzeug
 moto==5.1.5
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 mypy-extensions==1.1.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
-opentelemetry-api==1.34.0
+opentelemetry-api==1.34.1
     # via
     #   eodhp-utils
     #   opentelemetry-instrumentation
@@ -107,17 +107,17 @@ opentelemetry-api==1.34.0
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.55b0
+opentelemetry-instrumentation==0.55b1
     # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.55b0
+opentelemetry-instrumentation-logging==0.55b1
     # via eodhp-utils
-opentelemetry-processor-baggage==0.55b0
+opentelemetry-processor-baggage==0.55b1
     # via eodhp-utils
-opentelemetry-sdk==1.34.0
+opentelemetry-sdk==1.34.1
     # via
     #   eodhp-utils
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.55b0
+opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
@@ -131,7 +131,7 @@ packaging==25.0
 pathspec==0.12.1
     # via black
 pip-tools==7.4.1
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 platformdirs==4.3.8
     # via
     #   black
@@ -139,7 +139,7 @@ platformdirs==4.3.8
 pluggy==1.6.0
     # via pytest
 pre-commit==4.2.0
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 pulsar-client==3.7.0
     # via eodhp-utils
 pycparser==2.22
@@ -154,15 +154,15 @@ pysubnettree==0.37
     # via eodhp-utils
 pytest==8.4.0
     # via
-    #   Harvest-Transformer (pyproject.toml)
+    #   harvest-transformer (pyproject.toml)
     #   pytest-mock
     #   pytest-xdist
 pytest-mock==3.14.1
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 pytest-watcher==0.4.3
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 pytest-xdist==3.7.0
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   botocore
@@ -171,17 +171,17 @@ python-json-logger==3.3.0
     # via eodhp-utils
 pyyaml==6.0.2
     # via
-    #   Harvest-Transformer (pyproject.toml)
+    #   harvest-transformer (pyproject.toml)
     #   pre-commit
     #   responses
 referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.3
+requests==2.32.4
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
+    #   harvest-transformer (pyproject.toml)
     #   moto
     #   responses
 responses==0.25.7
@@ -191,7 +191,7 @@ rpds-py==0.25.1
     #   jsonschema
     #   referencing
 ruff==0.11.13
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 s3transfer==0.13.0
     # via boto3
 six==1.17.0
@@ -215,7 +215,7 @@ urllib3==2.4.0
     #   requests
     #   responses
 validate-pyproject[all]==0.24.1
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 virtualenv==20.31.2
     # via pre-commit
 watchdog==6.0.0
@@ -230,7 +230,7 @@ wrapt==1.17.2
     #   opentelemetry-processor-baggage
 xmltodict==0.14.2
     # via moto
-zipp==3.22.0
+zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,12 +12,12 @@ beautifulsoup4==4.13.4
     # via html-sanitizer
 black==25.1.0
     # via Harvest-Transformer (pyproject.toml)
-boto3==1.37.38
+boto3==1.38.31
     # via
     #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
     #   moto
-botocore==1.37.38
+botocore==1.38.31
     # via
     #   Harvest-Transformer (pyproject.toml)
     #   boto3
@@ -26,7 +26,7 @@ botocore==1.37.38
     #   s3transfer
 build==1.2.2.post1
     # via pip-tools
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   pulsar-client
     #   requests
@@ -34,26 +34,22 @@ cffi==1.17.1
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.1
     # via
     #   Harvest-Transformer (pyproject.toml)
     #   black
     #   pip-tools
-cryptography==44.0.2
+cryptography==45.0.3
     # via moto
-deprecated==1.2.18
-    # via
-    #   opentelemetry-api
-    #   opentelemetry-semantic-conventions
 distlib==0.3.9
     # via virtualenv
-eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.8
+eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@multithreading-not-using-multi-threads
     # via Harvest-Transformer (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist
-faker==37.1.0
+faker==37.3.0
     # via eodhp-utils
 fastjsonschema==2.21.1
     # via validate-pyproject
@@ -61,11 +57,11 @@ filelock==3.18.0
     # via virtualenv
 html-sanitizer==2.5.0
     # via Harvest-Transformer (pyproject.toml)
-identify==2.6.10
+identify==2.6.12
     # via pre-commit
 idna==3.10
     # via requests
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via opentelemetry-api
 iniconfig==2.1.0
     # via pytest
@@ -81,13 +77,13 @@ jsonpatch==1.33
     # via Harvest-Transformer (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via
     #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
-lxml==5.3.2
+lxml==5.4.0
     # via
     #   html-sanitizer
     #   lxml-html-clean
@@ -97,13 +93,13 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto==5.1.4
+moto==5.1.5
     # via Harvest-Transformer (pyproject.toml)
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
-opentelemetry-api==1.32.1
+opentelemetry-api==1.34.0
     # via
     #   eodhp-utils
     #   opentelemetry-instrumentation
@@ -111,17 +107,17 @@ opentelemetry-api==1.32.1
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.53b1
+opentelemetry-instrumentation==0.55b0
     # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.53b1
+opentelemetry-instrumentation-logging==0.55b0
     # via eodhp-utils
-opentelemetry-processor-baggage==0.53b1
+opentelemetry-processor-baggage==0.55b0
     # via eodhp-utils
-opentelemetry-sdk==1.32.1
+opentelemetry-sdk==1.34.0
     # via
     #   eodhp-utils
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.53b1
+opentelemetry-semantic-conventions==0.55b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
@@ -136,32 +132,36 @@ pathspec==0.12.1
     # via black
 pip-tools==7.4.1
     # via Harvest-Transformer (pyproject.toml)
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via
     #   black
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 pre-commit==4.2.0
     # via Harvest-Transformer (pyproject.toml)
-pulsar-client==3.6.1
+pulsar-client==3.7.0
     # via eodhp-utils
 pycparser==2.22
     # via cffi
+pygments==2.19.1
+    # via pytest
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.3.5
+pysubnettree==0.37
+    # via eodhp-utils
+pytest==8.4.0
     # via
     #   Harvest-Transformer (pyproject.toml)
     #   pytest-mock
     #   pytest-xdist
-pytest-mock==3.14.0
+pytest-mock==3.14.1
     # via Harvest-Transformer (pyproject.toml)
 pytest-watcher==0.4.3
     # via Harvest-Transformer (pyproject.toml)
-pytest-xdist==3.6.1
+pytest-xdist==3.7.0
     # via Harvest-Transformer (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
@@ -181,28 +181,31 @@ referencing==0.36.2
 requests==2.32.3
     # via
     #   Harvest-Transformer (pyproject.toml)
+    #   eodhp-utils
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-rpds-py==0.24.0
+rpds-py==0.25.1
     # via
     #   jsonschema
     #   referencing
-ruff==0.11.6
+ruff==0.11.13
     # via Harvest-Transformer (pyproject.toml)
-s3transfer==0.11.5
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil
 soupsieve==2.7
     # via beautifulsoup4
-trove-classifiers==2025.4.11.15
+trove-classifiers==2025.5.9.12
     # via validate-pyproject
-typing-extensions==4.13.2
+typing-extensions==4.14.0
     # via
     #   beautifulsoup4
+    #   opentelemetry-api
     #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   referencing
 tzdata==2025.2
     # via faker
@@ -213,7 +216,7 @@ urllib3==2.4.0
     #   responses
 validate-pyproject[all]==0.24.1
     # via Harvest-Transformer (pyproject.toml)
-virtualenv==20.30.0
+virtualenv==20.31.2
     # via pre-commit
 watchdog==6.0.0
     # via pytest-watcher
@@ -223,12 +226,11 @@ wheel==0.45.1
     # via pip-tools
 wrapt==1.17.2
     # via
-    #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-processor-baggage
 xmltodict==0.14.2
     # via moto
-zipp==3.21.0
+zipp==3.22.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,15 +10,15 @@ attrs==25.3.0
     #   referencing
 beautifulsoup4==4.13.4
     # via html-sanitizer
-boto3==1.38.31
+boto3==1.38.33
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
-botocore==1.38.31
+    #   harvest-transformer (pyproject.toml)
+botocore==1.38.33
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   boto3
     #   eodhp-utils
+    #   harvest-transformer (pyproject.toml)
     #   s3transfer
 certifi==2025.4.26
     # via
@@ -27,13 +27,13 @@ certifi==2025.4.26
 charset-normalizer==3.4.2
     # via requests
 click==8.2.1
-    # via Harvest-Transformer (pyproject.toml)
-eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@multithreading-not-using-multi-threads
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
+eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.12
+    # via harvest-transformer (pyproject.toml)
 faker==37.3.0
     # via eodhp-utils
 html-sanitizer==2.5.0
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 idna==3.10
     # via requests
 importlib-metadata==8.7.0
@@ -43,13 +43,13 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 jsonpatch==1.33
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
 jsonschema==4.24.0
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
+    #   harvest-transformer (pyproject.toml)
 jsonschema-specifications==2025.4.1
     # via jsonschema
 lxml==5.4.0
@@ -58,7 +58,7 @@ lxml==5.4.0
     #   lxml-html-clean
 lxml-html-clean==0.4.2
     # via html-sanitizer
-opentelemetry-api==1.34.0
+opentelemetry-api==1.34.1
     # via
     #   eodhp-utils
     #   opentelemetry-instrumentation
@@ -66,17 +66,17 @@ opentelemetry-api==1.34.0
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.55b0
+opentelemetry-instrumentation==0.55b1
     # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.55b0
+opentelemetry-instrumentation-logging==0.55b1
     # via eodhp-utils
-opentelemetry-processor-baggage==0.55b0
+opentelemetry-processor-baggage==0.55b1
     # via eodhp-utils
-opentelemetry-sdk==1.34.0
+opentelemetry-sdk==1.34.1
     # via
     #   eodhp-utils
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.55b0
+opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
@@ -91,15 +91,15 @@ python-dateutil==2.9.0.post0
 python-json-logger==3.3.0
     # via eodhp-utils
 pyyaml==6.0.2
-    # via Harvest-Transformer (pyproject.toml)
+    # via harvest-transformer (pyproject.toml)
 referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.3
+requests==2.32.4
     # via
-    #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
+    #   harvest-transformer (pyproject.toml)
 rpds-py==0.25.1
     # via
     #   jsonschema
@@ -127,5 +127,5 @@ wrapt==1.17.2
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-processor-baggage
-zipp==3.22.0
+zipp==3.23.0
     # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,37 +10,33 @@ attrs==25.3.0
     #   referencing
 beautifulsoup4==4.13.4
     # via html-sanitizer
-boto3==1.37.38
+boto3==1.38.31
     # via
     #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
-botocore==1.37.38
+botocore==1.38.31
     # via
     #   Harvest-Transformer (pyproject.toml)
     #   boto3
     #   eodhp-utils
     #   s3transfer
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   pulsar-client
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.1
     # via Harvest-Transformer (pyproject.toml)
-deprecated==1.2.18
-    # via
-    #   opentelemetry-api
-    #   opentelemetry-semantic-conventions
-eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.8
+eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@multithreading-not-using-multi-threads
     # via Harvest-Transformer (pyproject.toml)
-faker==37.1.0
+faker==37.3.0
     # via eodhp-utils
 html-sanitizer==2.5.0
     # via Harvest-Transformer (pyproject.toml)
 idna==3.10
     # via requests
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via opentelemetry-api
 jmespath==1.0.1
     # via
@@ -50,19 +46,19 @@ jsonpatch==1.33
     # via Harvest-Transformer (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via
     #   Harvest-Transformer (pyproject.toml)
     #   eodhp-utils
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
-lxml==5.3.2
+lxml==5.4.0
     # via
     #   html-sanitizer
     #   lxml-html-clean
 lxml-html-clean==0.4.2
     # via html-sanitizer
-opentelemetry-api==1.32.1
+opentelemetry-api==1.34.0
     # via
     #   eodhp-utils
     #   opentelemetry-instrumentation
@@ -70,23 +66,25 @@ opentelemetry-api==1.32.1
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.53b1
+opentelemetry-instrumentation==0.55b0
     # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.53b1
+opentelemetry-instrumentation-logging==0.55b0
     # via eodhp-utils
-opentelemetry-processor-baggage==0.53b1
+opentelemetry-processor-baggage==0.55b0
     # via eodhp-utils
-opentelemetry-sdk==1.32.1
+opentelemetry-sdk==1.34.0
     # via
     #   eodhp-utils
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.53b1
+opentelemetry-semantic-conventions==0.55b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
 packaging==25.0
     # via opentelemetry-instrumentation
-pulsar-client==3.6.1
+pulsar-client==3.7.0
+    # via eodhp-utils
+pysubnettree==0.37
     # via eodhp-utils
 python-dateutil==2.9.0.post0
     # via botocore
@@ -99,21 +97,25 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.3
-    # via Harvest-Transformer (pyproject.toml)
-rpds-py==0.24.0
+    # via
+    #   Harvest-Transformer (pyproject.toml)
+    #   eodhp-utils
+rpds-py==0.25.1
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.5
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil
 soupsieve==2.7
     # via beautifulsoup4
-typing-extensions==4.13.2
+typing-extensions==4.14.0
     # via
     #   beautifulsoup4
+    #   opentelemetry-api
     #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   referencing
 tzdata==2025.2
     # via faker
@@ -123,8 +125,7 @@ urllib3==2.4.0
     #   requests
 wrapt==1.17.2
     # via
-    #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-processor-baggage
-zipp==3.21.0
+zipp==3.22.0
     # via importlib-metadata

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,66 +56,66 @@ def test_reformat_key_collection():
     )
 
 
-@mock.patch("harvest_transformer.transformer.s3_client.get_object")
 @mock.patch.dict(
     os.environ, {"PATCH_PREFIX": "patches", "PATCH_BUCKET": "catalogue-population-eodhp-dev"}
 )
-def test_get_patch_found(mock_get_object):
+def test_get_patch_found():
     # Mock the S3 response
     mock_response = {
         "Body": mock.Mock(
             read=mock.Mock(return_value=json.dumps({"patch": "data"}).encode("utf-8"))
         )
     }
-    mock_get_object.return_value = mock_response
+    mock_s3_client = mock.Mock()
+    mock_s3_client.get_object.return_value = mock_response
 
     cat_path = "supported-datasets/ceda-stac-catalogue/cmip6"
 
-    patch_data = get_patch(cat_path)
+    patch_data = get_patch(mock_s3_client, cat_path)
 
     assert patch_data is not None
     assert patch_data == {"patch": "data"}
-    mock_get_object.assert_called_once_with(
+    mock_s3_client.get_object.assert_called_once_with(
         Bucket="catalogue-population-eodhp-dev",
         Key="patches/supported-datasets/ceda-stac-catalogue/cmip6",
     )
 
 
-@mock.patch("harvest_transformer.transformer.s3_client.get_object")
 @mock.patch.dict(
     os.environ, {"PATCH_PREFIX": "patches", "PATCH_BUCKET": "catalogue-population-eodhp-dev"}
 )
-def test_get_patch_not_found(mock_get_object):
+def test_get_patch_not_found():
     # Mock the S3 ClientError for NoSuchKey
-    mock_get_object.side_effect = botocore.exceptions.ClientError(
+    mock_s3_client = mock.Mock()
+    mock_s3_client.get_object.side_effect = botocore.exceptions.ClientError(
         {"Error": {"Code": "NoSuchKey"}}, "get_object"
     )
 
     cat_path = "supported-datasets/ceda-stac-catalogue/cmip6"
 
-    patch_data = get_patch(cat_path)
+    patch_data = get_patch(mock_s3_client, cat_path)
 
     assert patch_data is None
-    mock_get_object.assert_called_once_with(
+    mock_s3_client.get_object.assert_called_once_with(
         Bucket="catalogue-population-eodhp-dev",
         Key="patches/supported-datasets/ceda-stac-catalogue/cmip6",
     )
 
 
-@mock.patch("harvest_transformer.transformer.s3_client.get_object")
 @mock.patch.dict(
     os.environ, {"PATCH_PREFIX": "patches", "PATCH_BUCKET": "catalogue-population-eodhp-dev"}
 )
-def test_get_patch_unexpected_error(mock_get_object):
+def test_get_patch_unexpected_error():
     # Mock an unexpected error
-    mock_get_object.side_effect = Exception("Unexpected error")
+    mock_s3_client = mock.Mock()
+    mock_s3_client.get_object.side_effect = Exception("Unexpected error")
 
     cat_path = "supported-datasets/ceda-stac-catalogue/cmip6"
 
-    patch_data = get_patch(cat_path)
+    patch_data = get_patch(mock_s3_client, cat_path)
 
     assert patch_data is None
-    mock_get_object.assert_called_once_with(
+    mock_s3_client.get_object.assert_called_once_with(
         Bucket="catalogue-population-eodhp-dev",
         Key="patches/supported-datasets/ceda-stac-catalogue/cmip6",
     )

--- a/tests/test_render_processor.py
+++ b/tests/test_render_processor.py
@@ -97,6 +97,7 @@ def test_sentinel2_ard_collection(mock_sentinel_collection, mock_file_name):
         entry_body=mock_sentinel_collection,
         output_root=OUTPUT_ROOT,
         processors=processor,
+        workspace="test",
     )
 
     # Read output in as a dictionary
@@ -141,6 +142,7 @@ def test_sentinel2_ard_collection__missing_fields(
         entry_body=mock_sentinel_collection,
         output_root=OUTPUT_ROOT,
         processors=processor,
+        workspace="test",
     )
 
     # Read output in as a dictionary
@@ -180,6 +182,7 @@ def test_not_sentinel2_ard_collection(key, value, mock_sentinel_collection, mock
         entry_body=mock_sentinel_collection,
         output_root=OUTPUT_ROOT,
         processors=processor,
+        workspace="test",
     )
 
     # Read output in as a dictionary

--- a/tests/test_transformer_messager.py
+++ b/tests/test_transformer_messager.py
@@ -31,6 +31,7 @@ def test_process_update(mock_process_update_body):
         ]
 
         test_transformer_messager = TransformerMessager(
+            processors=[],
             s3_client=s3,
             output_bucket="files_bucket_name",
             cat_output_prefix="transformed",
@@ -67,6 +68,7 @@ def test_process_update_body(mock_transform, mock_get_workspace_from_msg):
     mock_transform.return_value = stac_item
     mock_get_workspace_from_msg.return_value = "test-workspace"
     test_transformer_messager = TransformerMessager(
+        processors=[],
         s3_client=mock_s3_client,
         output_bucket="files_bucket_name",
         cat_output_prefix="transformed",
@@ -86,6 +88,7 @@ def test_process_update_body(mock_transform, mock_get_workspace_from_msg):
     )
 
     mock_transform.assert_called_once_with(
+        processors=[],
         file_name="test/key/path.json",
         entry_body=stac_item,
         source="test/",
@@ -107,6 +110,7 @@ def test_process_delete(mock_transform, mock_get_workspace_from_msg):
     mock_transform.return_value = stac_item
     mock_get_workspace_from_msg.get.return_value = "test-workspace"
     test_transformer_messager = TransformerMessager(
+        processors=[],
         s3_client=mock_s3_client,
         output_bucket="files_bucket_name",
         cat_output_prefix="transformed",

--- a/tests/test_transformer_messager.py
+++ b/tests/test_transformer_messager.py
@@ -95,6 +95,7 @@ def test_process_update_body(mock_transform, mock_get_workspace_from_msg):
         target="test-catalog/",
         output_root="https://test-url-root.org.uk",
         workspace="test-workspace",
+        s3_client=mock_s3_client,
     )
 
     assert result == [expected_action]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,6 @@ def test_get_file_from_url_fail():
 
 
 def test_get_file_from_url_pass():
-    url = "https://test.eodatahub.org.uk/api/catalogue/stac/"
+    url = "https://example.com/"
     body = get_file_from_url(url)
     assert body is not None

--- a/tests/test_workflow_processor.py
+++ b/tests/test_workflow_processor.py
@@ -16,8 +16,7 @@ with patch(
     "harvest_transformer.link_processor.LinkProcessor.map_licence_codes_to_filenames"
 ) as mock_map_licence_codes_to_filenames:
     mock_map_licence_codes_to_filenames.return_value = {}
-    workspace = "mock_workspace"
-    PROCESSORS = [WorkflowProcessor(), LinkProcessor("workspace")]
+    PROCESSORS = [WorkflowProcessor(), LinkProcessor()]
 
 
 def test_workflows_with_only_cwl_input_valid():
@@ -37,6 +36,7 @@ def test_workflows_with_only_cwl_input_valid():
         entry_body=file_json,
         output_root=OUTPUT_ROOT,
         processors=workflow_processor,
+        workspace="test",
     )
 
     # Read output in as a dictionary
@@ -67,6 +67,7 @@ def test_workflows_with_only_cwl_input_invalid():
         entry_body=file_json,
         output_root=OUTPUT_ROOT,
         processors=workflow_processor,
+        workspace="test",
     )
     # Read output in as a dictionary
     output_json = json.loads(output)
@@ -107,6 +108,7 @@ def test_workflows_dont_overwrite():
         entry_body=file_json,
         output_root=OUTPUT_ROOT,
         processors=workflow_processor,
+        workspace="test",
     )
 
     # Read output in as a dictionary
@@ -133,6 +135,7 @@ def test_workflows_fill_blanks():
         entry_body=file_json,
         output_root=OUTPUT_ROOT,
         processors=workflow_processor,
+        workspace="test",
     )
     # Read output in as a dictionary
     output_json = json.loads(output)
@@ -161,6 +164,7 @@ def test_workflows_correct_self_link():
         entry_body=file_json,
         output_root=OUTPUT_ROOT,
         processors=workflow_processor,
+        workspace="test",
     )
 
     # Read output in as a dictionary
@@ -190,6 +194,7 @@ def test_workflows_and_links_with_new_self_link():
         entry_body=file_json,
         output_root=OUTPUT_ROOT,
         processors=PROCESSORS,
+        workspace="test",
     )
     # Read output in as a dictionary
     output_json = json.loads(output)
@@ -220,6 +225,7 @@ def test_workflows_and_links_with_only_cwl_input_valid():
         entry_body=file_json,
         output_root=OUTPUT_ROOT,
         processors=PROCESSORS,
+        workspace="test",
     )
 
     # Read output in as a dictionary


### PR DESCRIPTION
This change
* Updates to a version of eodhp-utils with working threading (the version will need to change again once it's tagged)
* Fixes a bug that stopped the correct number of threads being passed to Pulsar. The number is fixed after the first call to get_pulsar_client, so it needs to be correct there.
* Increases the HTTP connection pool for S3 access to cope with the larger number of threads.
* Scans the S3 bucket of licences once, not for every single message.
